### PR TITLE
CDM-328: Switch Insert* classes to client methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,10 @@ Also checks [event processor](https://github.com/kbase/cdm-spark-events) status 
 * Each module should have its own test file. Eventually these will be expanded into unit tests
 * Any code committed must have regular code and user documentation so that future devs
   converting the code to production can understand it.
-* When releasing, create a tag and release in Github in 0.X.X format.
+* When releasing:
+  * Update release notes
+  * Update the version in client.py
+  * Create a tag and release in Github in 0.X.X format.
 
 ### Running tests
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,10 @@
 # CDM Task Service Client Release Notes
 
+## 0.2.0 (25/08/18)
+
+* Removed the `InsertFiles` and `InsertContainerNumber` classes in favor of classmethods
+  on the client.
+
 ## 0.1.0 (25/07/11)
 
 * Initial release


### PR DESCRIPTION
Remove the need to import additional classes; user testing showed this was confusing