### PR TITLE
Handle case where stdout doesn't have a `buffer` attribute

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,10 @@
 # CDM Task Service Client Release Notes
 
+# 0.2.3 (26/01/14)
+
+* Update the `print_logs()` function to handle the case where the `stdout` stream doesn't
+  have a `buffer` attribute.
+
 # 0.2.2 (26/01/12)
 
 * Added a method to cancel a job.


### PR DESCRIPTION
e.g. Jupyter notebooks